### PR TITLE
feat: generate material assets if not present

### DIFF
--- a/Assets/Speckle Connector/ConverterUnity.Geometry.cs
+++ b/Assets/Speckle Connector/ConverterUnity.Geometry.cs
@@ -396,10 +396,15 @@ namespace Objects.Converter.Unity
       if (renderMaterial != null)
       {
         // 1. match material by name, if any
-        var matByName = ContextObjects.FirstOrDefault(x => ((Material)x.NativeObject).name == renderMaterial.name);
-        if (matByName != null)
+        Material matByName = null;
+        
+        foreach (var _mat in ContextObjects)
         {
-          return matByName.NativeObject as Material;
+          if (((Material)_mat.NativeObject).name == renderMaterial.name)
+          {
+            if (matByName == null) matByName = (Material)_mat.NativeObject;
+            else Debug.LogWarning("There is more than one Material with the name \'" + renderMaterial.name + "\'!", (Material)_mat.NativeObject);
+          }
         }
 
         // 2. re-create material by setting diffuse color and transparency on standard shaders
@@ -411,10 +416,22 @@ namespace Objects.Converter.Unity
 
         var c = renderMaterial.diffuse.ToUnityColor();
         mat.color = new Color(c.r, c.g, c.b, Convert.ToSingle(renderMaterial.opacity));
+        mat.name = renderMaterial.name;
+
+
+#if UNITY_EDITOR
+        if (Speckle.ConnectorUnity.StreamManager.GenerateMaterials)
+        {
+          if (!AssetDatabase.IsValidFolder("Assets/Resources")) AssetDatabase.CreateFolder("Assets", "Resources");
+          if (!AssetDatabase.IsValidFolder("Assets/Resources/Materials")) AssetDatabase.CreateFolder("Assets/Resources", "Materials");
+          if (!AssetDatabase.IsValidFolder("Assets/Resources/Materials/Speckle Generated")) AssetDatabase.CreateFolder("Assets/Resources/Materials", "Speckle Generated");
+          if (AssetDatabase.LoadAllAssetsAtPath("Assets/Resources/Materials/Speckle Generated/" + mat.name + ".mat").Length == 0) AssetDatabase.CreateAsset(mat, "Assets/Resources/Materials/Speckle Generated/" + mat.name + ".mat");
+        }
+#endif
+
 
         return mat;
       }
-
       // 3. if not renderMaterial was passed, the default shader will be used 
       return mat;
     }

--- a/Assets/Speckle Connector/Editor/StreamManagerEditor.cs
+++ b/Assets/Speckle Connector/Editor/StreamManagerEditor.cs
@@ -295,6 +295,17 @@ namespace Speckle.ConnectorUnity
       EditorGUILayout.EndHorizontal();
       #endregion
 
+      #region Generate Materials
+      EditorGUILayout.BeginHorizontal();
+
+      GUILayout.Label("Generate material assets");
+      GUILayout.FlexibleSpace();
+      StreamManager.GenerateMaterials = GUILayout.Toggle(StreamManager.GenerateMaterials, "");
+
+      EditorGUILayout.EndHorizontal();
+      #endregion
+
+
       EditorGUILayout.BeginHorizontal();
 
       if (GUILayout.Button("Receive!"))

--- a/Assets/Speckle Connector/RecursiveConverter.cs
+++ b/Assets/Speckle Connector/RecursiveConverter.cs
@@ -24,12 +24,13 @@ namespace Speckle.ConnectorUnity
     {
       //using the ApplicationPlaceholderObject to pass materials
       //available in Assets/Materials to the converters
-      var materials = Resources.LoadAll("Materials", typeof(Material)).Cast<Material>()
-          .Select(x => new ApplicationPlaceholderObject { NativeObject = x }).ToList();
-      _converter.SetContextObjects(materials);
+      var materials = Resources.LoadAll("", typeof(Material)).Cast<Material>().ToArray();
+      if (materials.Length == 0) Debug.LogWarning("To automatically assign materials to recieved meshes, materials have to be in the \'Assets/Resources\' folder!");
+      var placeholderObjects = materials.Select(x => new ApplicationPlaceholderObject { NativeObject = x }).ToList();
+      _converter.SetContextObjects(placeholderObjects);
 
 
-      // case 1: it's an item that has a direct conversion method, eg a point
+            // case 1: it's an item that has a direct conversion method, eg a point
       if (_converter.CanConvertToNative(@base))
       {
         var go = TryConvertItemToNative(@base);

--- a/Assets/Speckle Connector/StreamManager.cs
+++ b/Assets/Speckle Connector/StreamManager.cs
@@ -31,6 +31,11 @@ namespace Speckle.ConnectorUnity
     public List<Stream> Streams;
     public List<Branch> Branches;
 
+
+#if UNITY_EDITOR
+    public static bool GenerateMaterials = false;
+#endif
+
     public GameObject ConvertRecursivelyToNative(Base @base, string id)
     {
 


### PR DESCRIPTION
I think it is very useful to generate the materials that are used in an received model to easily adjust the look and to ease the usage of the receiver for beginners.