### PR TITLE
added assemblies in preparation for creating a Package #7

### DIFF
--- a/Assets/Extra/Speckle.Extra.asmdef
+++ b/Assets/Extra/Speckle.Extra.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "Speckle.Extra"
+}

--- a/Assets/Speckle Connector/Editor/Speckle.Connector.Editor.asmdef
+++ b/Assets/Speckle Connector/Editor/Speckle.Connector.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Speckle.Connector.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:eed1b8b83e2c0074d9e5de2348e3ff72"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Speckle Connector/Speckle.Connector.asmdef
+++ b/Assets/Speckle Connector/Speckle.Connector.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "Speckle.Connector"
+}


### PR DESCRIPTION
This would be required before creating a package for unity. Essentially it breaks scripts down into different assemblies and you reference any dependencies. It will speed up builds on newer version of unity as well.

To create a package there would be a need for a bit of refactoring on the structure so I was a bit hesitant to do it with a PR pending. 