### PR TITLE
fix: editor namespace break

### DIFF
--- a/Assets/Extra/RosolynDirectoryCreator.cs
+++ b/Assets/Extra/RosolynDirectoryCreator.cs
@@ -1,7 +1,8 @@
 ﻿using System.IO;
 using System.Text.RegularExpressions;
-using UnityEditor;
 using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
 
 namespace Speckle.ConnectorUnity
 {
@@ -29,4 +30,4 @@ namespace Speckle.ConnectorUnity
       }
     }
   }
-}
+}}

--- a/Assets/Extra/RosolynDirectoryCreator.cs
+++ b/Assets/Extra/RosolynDirectoryCreator.cs
@@ -30,4 +30,4 @@ namespace Speckle.ConnectorUnity
       }
     }
   }
-}}
+#endif


### PR DESCRIPTION
quick fix for protecting build process from editor calls mentioned in  #37 