### PR TITLE
Fix playground sending.

### DIFF
--- a/Assets/Extra/Selectable.cs
+++ b/Assets/Extra/Selectable.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 
 //Thanks to : https://sharpcoderblog.com/blog/unity-3d-rts-style-unit-selection
+[AddComponentMenu("Speckle/Playground/Selectable"), DisallowMultipleComponent]
 public class Selectable : MonoBehaviour
 {
 
@@ -43,6 +44,7 @@ public class Selectable : MonoBehaviour
     if (SelectionManager.selectables.Contains(this))
     {
       SelectionManager.selectables.Remove(this);
+      SelectionManager.selectedObjects.Remove(this);
     }
   }
 }

--- a/Assets/Extra/SelectionManager.cs
+++ b/Assets/Extra/SelectionManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 
 //Thanks to : https://sharpcoderblog.com/blog/unity-3d-rts-style-unit-selection
+[AddComponentMenu("Speckle/Playground/Selection Manager"), DisallowMultipleComponent]
 public class SelectionManager : MonoBehaviour
 {
   public Texture topLeftBorder;
@@ -32,7 +33,7 @@ public class SelectionManager : MonoBehaviour
   Vector3 mousePosition1;
 
   public static List<Selectable> selectables = new List<Selectable>();
-  public static List<int> selectedObjects = new List<int>();
+  public static List<Selectable> selectedObjects = new List<Selectable>();
 
   // Update is called once per frame
   void Update()
@@ -66,7 +67,7 @@ public class SelectionManager : MonoBehaviour
         Bounds viewportBounds = GetViewportBounds(camera, mousePosition1, Input.mousePosition);
         if (viewportBounds.Contains(camera.WorldToViewportPoint(selectables[i].transform.position)))
         {
-          selectedObjects.Add(i);
+          selectedObjects.Add(selectables[i]);
         }
       }
     }
@@ -86,7 +87,7 @@ public class SelectionManager : MonoBehaviour
       Camera camera = Camera.main;
       for (int i = 0; i < selectedObjects.Count; i++)
       {
-        DrawSelectionIndicator(camera, selectables[selectedObjects[i]].GetObjectBounds());
+        DrawSelectionIndicator(camera, selectedObjects[i].GetObjectBounds());
       }
     }
   }

--- a/Assets/InteractionLogic.cs
+++ b/Assets/InteractionLogic.cs
@@ -106,7 +106,6 @@ namespace Speckle.ConnectorUnity
       InitRemove();
 
       var sender = gameObject.AddComponent<Sender>();
-      //sender.Stream = stream;
 
       var btn = gameObject.transform.Find("Btn").GetComponentInChildren<Button>();
 
@@ -125,9 +124,9 @@ namespace Speckle.ConnectorUnity
       btn.onClick.AddListener(() =>
         {
           var objs = new List<GameObject>();
-          foreach (var index in SelectionManager.selectedObjects)
+          foreach (var s in SelectionManager.selectedObjects)
           {
-            objs.Add(SelectionManager.selectables[index].gameObject);
+            objs.Add(s.gameObject);
           }
 
           if (!objs.Any())

--- a/Assets/Speckle Connector/Editor/StreamManagerEditor.cs
+++ b/Assets/Speckle Connector/Editor/StreamManagerEditor.cs
@@ -311,15 +311,17 @@ namespace Speckle.ConnectorUnity
 
       EditorGUILayout.BeginHorizontal();
 
-      if (GUILayout.Button("Receive!"))
+      bool receive = GUILayout.Button("Receive!");
+      
+      EditorGUILayout.EndHorizontal();
+      
+      if (receive)
       {
         await Receive();
       }
+    
 
-
-      GUILayout.EndHorizontal();
     }
-
-
+    
   }
 }

--- a/Assets/Speckle Connector/Receiver.cs
+++ b/Assets/Speckle Connector/Receiver.cs
@@ -162,7 +162,7 @@ namespace Speckle.ConnectorUnity
 
     private void OnDestroy()
     {
-      Client.CommitCreatedSubscription.Dispose();
+      Client?.CommitCreatedSubscription?.Dispose();
     }
 
     #endregion

--- a/Assets/Speckle Connector/RecursiveConverter.cs
+++ b/Assets/Speckle Connector/RecursiveConverter.cs
@@ -25,7 +25,7 @@ namespace Speckle.ConnectorUnity
       //using the ApplicationPlaceholderObject to pass materials
       //available in Assets/Materials to the converters
       var materials = Resources.LoadAll("", typeof(Material)).Cast<Material>().ToArray();
-      if (materials.Length == 0) Debug.LogWarning("To automatically assign materials to recieved meshes, materials have to be in the \'Assets/Resources\' folder!");
+      if (materials.Length == 0) Debug.Log("To automatically assign materials to recieved meshes, materials have to be in the \'Assets/Resources\' folder!");
       var placeholderObjects = materials.Select(x => new ApplicationPlaceholderObject { NativeObject = x }).ToList();
       _converter.SetContextObjects(placeholderObjects);
 
@@ -163,8 +163,6 @@ namespace Speckle.ConnectorUnity
           throw new SpeckleException(e.Message, e, true, SentryLevel.Error);
         }
       }
-
-      return null;
     }
 
 

--- a/Assets/Speckle Connector/StreamManager.cs
+++ b/Assets/Speckle Connector/StreamManager.cs
@@ -13,6 +13,7 @@ using UnityEngine.Events;
 namespace Speckle.ConnectorUnity
 {
   [ExecuteAlways]
+  [AddComponentMenu("Speckle/Stream Manager")]
   public class StreamManager : MonoBehaviour
   {
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
-    "com.unity.collab-proxy": "1.7.1",
+    "com.unity.collab-proxy": "1.13.5",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.11",
-    "com.unity.ide.vscode": "1.2.3",
-    "com.unity.test-framework": "1.1.27",
+    "com.unity.ide.vscode": "1.2.4",
+    "com.unity.test-framework": "1.1.29",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -7,11 +7,12 @@
       "dependencies": {}
     },
     "com.unity.collab-proxy": {
-      "version": "1.7.1",
+      "version": "1.13.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "2.0.0"
+        "com.unity.nuget.newtonsoft-json": "2.0.0",
+        "com.unity.services.core": "1.0.1"
       },
       "url": "https://packages.unity.com"
     },
@@ -41,7 +42,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.vscode": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -54,8 +55,17 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.services.core": {
+      "version": "1.0.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.unitywebrequest": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
-      "version": "1.1.27",
+      "version": "1.1.29",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.17f1
-m_EditorVersionWithRevision: 2020.3.17f1 (a4537701e4ab)
+m_EditorVersion: 2020.3.21f1
+m_EditorVersionWithRevision: 2020.3.21f1 (a38c86f6690f)

--- a/ProjectSettings/SceneTemplateSettings.json
+++ b/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,167 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicMaterial",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": false
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "ignore": true,
+            "defaultInstantiationMode": 1,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "ignore": false,
+            "defaultInstantiationMode": 0,
+            "supportsModification": true
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "ignore": false,
+        "defaultInstantiationMode": 1,
+        "supportsModification": true
+    },
+    "newSceneOverride": 0
+}


### PR DESCRIPTION
Fixed bug with object selection in speckle playground that caused an exception to be thrown on send operations.

Also fixed some other minor extraneous warnigns and errors that would appear in console.
- Changed materials message from a warning to a log
- Fixed "`EditorGUILayout.EndHorizontal` must be called after `EditorGUILayout.BeginHorizontal`" error message seen on streams that take a few seconds to receive.

Also upgraded the project to 2020.3.21.