### PR TITLE
Converter refactor

### DIFF
--- a/Assets/Extra/Speckle.Extra.asmdef
+++ b/Assets/Extra/Speckle.Extra.asmdef
@@ -1,3 +1,4 @@
 {
-	"name": "Speckle.Extra"
+	"name": "Speckle.Extra",
+	"references":[ "GUID:eed1b8b83e2c0074d9e5de2348e3ff72" ]
 }

--- a/Assets/Extra/SpecklePropertiesViewer.cs
+++ b/Assets/Extra/SpecklePropertiesViewer.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Speckle.ConnectorUnity;
+using UnityEngine;
+
+[RequireComponent(typeof(SpeckleProperties)), ExecuteAlways]
+public class SpecklePropertiesViewer : MonoBehaviour, ISerializationCallbackReceiver
+{
+    [SerializeField]
+    private List<KVP> Data;
+    
+    [SerializeField]
+    private int count;
+
+    private SpeckleProperties properties;
+    public void Awake()
+    {
+        properties = GetComponent<SpeckleProperties>();
+    }
+
+    public void OnBeforeSerialize()
+    {
+        Data = properties.Data.Select(x => new KVP(x.Key.ToString(), x.Value?.ToString())).ToList();
+        
+        count = properties.Data.Count;
+    }
+
+    public void OnAfterDeserialize()
+    {
+        Data.Clear();
+    }
+}
+
+[Serializable]
+struct KVP
+{
+    public string key, value;
+
+    public KVP(string k, string v)
+    {
+        key = k;
+        value = v;
+    }
+}

--- a/Assets/Extra/SpecklePropertiesViewer.cs.meta
+++ b/Assets/Extra/SpecklePropertiesViewer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6e625eb3c7bf324eb113aadb026a201
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SpecklePlayground.unity
+++ b/Assets/SpecklePlayground.unity
@@ -4006,11 +4006,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SelectedAccountIndex: 0
-  SelectedStreamIndex: 1
+  SelectedStreamIndex: 0
   SelectedBranchIndex: 0
   SelectedCommitIndex: 0
   OldSelectedAccountIndex: 0
-  OldSelectedStreamIndex: 1
+  OldSelectedStreamIndex: 0
 --- !u!4 &2060322467
 Transform:
   m_ObjectHideFlags: 0

--- a/Packages/systems.speckle.speckle-unity/ConverterUnity.Geometry.cs
+++ b/Packages/systems.speckle.speckle-unity/ConverterUnity.Geometry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Objects.Geometry;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Objects.Other;
@@ -510,10 +511,13 @@ namespace Objects.Converter.Unity
 #if UNITY_EDITOR
         if (StreamManager.GenerateMaterials)
         {
+          string name = mat.name.Trim(Path.GetInvalidFileNameChars());
           if (!AssetDatabase.IsValidFolder("Assets/Resources")) AssetDatabase.CreateFolder("Assets", "Resources");
           if (!AssetDatabase.IsValidFolder("Assets/Resources/Materials")) AssetDatabase.CreateFolder("Assets/Resources", "Materials");
           if (!AssetDatabase.IsValidFolder("Assets/Resources/Materials/Speckle Generated")) AssetDatabase.CreateFolder("Assets/Resources/Materials", "Speckle Generated");
-          if (AssetDatabase.LoadAllAssetsAtPath("Assets/Resources/Materials/Speckle Generated/" + mat.name + ".mat").Length == 0) AssetDatabase.CreateAsset(mat, "Assets/Resources/Materials/Speckle Generated/" + mat.name + ".mat");
+          
+          if (AssetDatabase.LoadAllAssetsAtPath("Assets/Resources/Materials/Speckle Generated/" + name + ".mat").Length == 0) AssetDatabase.CreateAsset(mat, "Assets/Resources/Materials/Speckle Generated/" + name + ".mat");
+          
         }
 #endif
         

--- a/Packages/systems.speckle.speckle-unity/ConverterUnity.Geometry.cs
+++ b/Packages/systems.speckle.speckle-unity/ConverterUnity.Geometry.cs
@@ -272,12 +272,15 @@ namespace Objects.Converter.Unity
 
       meshRenderer.sharedMaterials = nativeMaterials;
 
-      
-      var excludeProps = new HashSet<string>(typeof(Base).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+      var excludeProps = new HashSet<string>(typeof(Mesh).GetProperties(BindingFlags.Instance | BindingFlags.Public)
         .Select(x => x.Name));
-      
-      excludeProps.Add("displayValue");
-      excludeProps.Add("displayMesh");
+
+      foreach (string alias in DisplayValuePropertyAliases)
+      {
+        excludeProps.Add(alias);
+      }
+      excludeProps.Add("renderMaterial");
+      excludeProps.Add("elements");
       
       var properties = element.GetMembers()
         .Where(x => !excludeProps.Contains(x.Key))

--- a/Packages/systems.speckle.speckle-unity/ConverterUnity.cs
+++ b/Packages/systems.speckle.speckle-unity/ConverterUnity.cs
@@ -1,6 +1,7 @@
 ﻿using Speckle.Core.Kits;
 using Speckle.Core.Models;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -75,7 +76,7 @@ namespace Objects.Converter.Unity
 
     }
 
-    public IList<string> DisplayValuePropertyAliases { get; set; } = new[] {"displayValue", "displayMesh" };
+    public IList<string> DisplayValuePropertyAliases { get; set; } = new[] {"displayValue","@displayValue","displayMesh", "@displayMesh" };
     public object DisplayValueToNative(Base @object)
     {
       foreach (string alias in DisplayValuePropertyAliases)
@@ -83,7 +84,7 @@ namespace Objects.Converter.Unity
         switch (@object[alias])
         {
           //capture any other object that might have a mesh representation
-          case IEnumerable<Base> dvCollection:
+          case IList dvCollection:
             return MeshesToNative(@object, dvCollection.OfType<Mesh>().ToList());
           case Mesh dvMesh:
             return MeshesToNative(@object , new[] {dvMesh});
@@ -91,7 +92,7 @@ namespace Objects.Converter.Unity
             return ConvertToNative(dvBase);
         }
       }
-
+      Debug.LogWarning("displayValue had no convertable objects");
       return null;
     }
 
@@ -103,7 +104,7 @@ namespace Objects.Converter.Unity
     public List<object> ConvertToNative(List<Base> objects)
     {
       return objects.Select(x => ConvertToNative(x)).ToList();
-      ;
+      
     }
 
     public bool CanConvertToSpeckle(object @object)
@@ -136,12 +137,15 @@ namespace Objects.Converter.Unity
         case Mesh _:
           return true;
         default:
-          if (@object["displayValue"] is Base)
-            return true;
-          if (@object["displayValue"] is IEnumerable<Base>)
-            return true;
-          if (@object["displayMesh"] is Base)
-            return true;
+          
+           foreach (string alias in DisplayValuePropertyAliases)
+           {
+             if (@object[alias] is Base)
+               return true;
+             if (@object[alias] is IList)
+               return true;
+           }
+          
           return false;
       }
     }

--- a/Packages/systems.speckle.speckle-unity/Receiver.cs
+++ b/Packages/systems.speckle.speckle-unity/Receiver.cs
@@ -141,14 +141,18 @@ namespace Speckle.ConnectorUnity
         );
         Dispatcher.Instance().Enqueue(() =>
         {
-          
+          var root = new GameObject()
+          {
+            name = commitId,
+          };
+
           var rc = GetComponent<RecursiveConverter>();
-          var go = rc.ConvertRecursivelyToNative(@base, commitId);
+          var go = rc.RecursivelyConvertToNative(@base, root.transform);
           //remove previously received object
           if (DeleteOld && ReceivedData != null)
             Destroy(ReceivedData);
-          ReceivedData = go;
-          OnDataReceivedAction?.Invoke(go);
+          ReceivedData = root;
+          OnDataReceivedAction?.Invoke(root);
         });
       }
       catch (Exception e)

--- a/Packages/systems.speckle.speckle-unity/RecursiveConverter.cs
+++ b/Packages/systems.speckle.speckle-unity/RecursiveConverter.cs
@@ -131,7 +131,7 @@ namespace Speckle.ConnectorUnity
             //using the ApplicationPlaceholderObject to pass materials
             //available in Assets/Materials to the converters
             var materials = Resources.LoadAll("", typeof(Material)).Cast<Material>().ToArray();
-            if (materials.Length == 0) Debug.Log("To automatically assign materials to recieved meshes, materials have to be in the \'Assets/Resources\' folder!");
+            if (materials.Length == 0) Debug.Log("To automatically assign materials to received meshes, materials have to be in the \'Assets/Resources\' folder!");
             var placeholderObjects = materials.Select(x => new ApplicationPlaceholderObject { NativeObject = x }).ToList();
             ConverterInstance.SetContextObjects(placeholderObjects);
         }

--- a/Packages/systems.speckle.speckle-unity/StreamManager.cs
+++ b/Packages/systems.speckle.speckle-unity/StreamManager.cs
@@ -33,15 +33,28 @@ namespace Speckle.ConnectorUnity
     public static bool GenerateMaterials = false;
 #endif
 
-    public GameObject ConvertRecursivelyToNative(Base @base, string id)
+    public List<GameObject> ConvertRecursivelyToNative(Base @base, string id)
     {
 
       var rc = GetComponent<RecursiveConverter>();
       if (rc == null)
         rc = gameObject.AddComponent<RecursiveConverter>();
 
-      return rc.ConvertRecursivelyToNative(@base,
-          Branches[SelectedBranchIndex].commits.items[SelectedCommitIndex].id);
+      var rootObject = new GameObject()
+      {
+          name = id,
+      };
+      
+      return rc.RecursivelyConvertToNative(@base, rootObject.transform);
     }
+    
+#if UNITY_EDITOR
+    [ContextMenu("Open Speckle Stream in Browser")]
+    protected void OpenUrlInBrowser()
+    {
+        string url = $"{SelectedAccount.serverInfo.url}/streams/{SelectedStream.id}/commits/{Branches[SelectedBranchIndex].commits.items[SelectedCommitIndex].id}";
+        Application.OpenURL(url);
+    }
+#endif
   }
 }


### PR DESCRIPTION
The current Unity implementation of `RecursiveConverter` was written with only .NET objects in mind
And doesn't properly convert custom object models.

The main issue we were facing is with IFC imported geometry.

I have refactored the `RecursiveConverter` class to operate more similar to how it does in our Unreal Engine connector.
I also think it's a much cleaner approach (but happy to discuss this)