### PR TITLE
chore(domains): deprecate speckle.xyz for app.speckle.systems

### DIFF
--- a/Assets/Tests/PlayMode/ConvertToNativeTests.cs
+++ b/Assets/Tests/PlayMode/ConvertToNativeTests.cs
@@ -15,7 +15,7 @@ namespace Speckle.ConnectorUnity.Tests
     {
         private static IEnumerable<string> TestCases()
         {
-            yield return @"https://latest.speckle.dev/streams/c1faab5c62/commits/704984e22d";
+            yield return @"https://latest.speckle.systems/streams/c1faab5c62/commits/704984e22d";
         }
 
         private static Base Receive(string stream)

--- a/Packages/systems.speckle.speckle-unity/Runtime/Core/SpeckleCore2.xml
+++ b/Packages/systems.speckle.speckle-unity/Runtime/Core/SpeckleCore2.xml
@@ -804,9 +804,9 @@
                 Uri localIdentifier = GetLocalIdentifier();
                 Console.WriteLine(localIdentifier);
               </code>
-              For a fictional `User ID: 123` and `Server: https://speckle.xyz`, the output might look like this:
+              For a fictional `User ID: 123` and `Server: https://app.speckle.systems`, the output might look like this:
               <code>
-                https://speckle.xyz?id=123
+                https://app.speckle.systems?id=123
               </code>
             </example>
         </member>


### PR DESCRIPTION
Part of https://linear.app/speckle/issue/WEB-1337/update-hard-coded-references-to-specklexyz-and-latestspeckledev